### PR TITLE
Change to inline template in docs

### DIFF
--- a/website/docs/d/cloudinit_config.html.markdown
+++ b/website/docs/d/cloudinit_config.html.markdown
@@ -15,7 +15,7 @@ Renders a multi-part cloud-init config from source files.
 ```hcl
 # Render a part using a `template_file`
 data "template_file" "script" {
-  template = "${file("${path.module}/init.tpl")}"
+  template = "$${consul_address}:1234"
 
   vars {
     consul_address = "${aws_instance.consul.private_ip}"


### PR DESCRIPTION
## Overview
Rather than include an external `template_file` in the example just reference an inline template. Additionally, an example for an external `template_file` is already show [here](https://www.terraform.io/docs/providers/template/d/file.html#example-usage)

This should fulfill the documentation fix for #5 

~Rob